### PR TITLE
Assign CustomEscape as Escape Scenario

### DIFF
--- a/Common Utilities/EventHandlers/PlayerHandlers.cs
+++ b/Common Utilities/EventHandlers/PlayerHandlers.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using ConfigObjects;
+using Exiled.API.Enums;
 using Exiled.API.Features;
 using Exiled.API.Features.Roles;
 using Exiled.CustomItems.API.Features;
@@ -130,6 +131,7 @@ public class PlayerHandlers
         {
             ev.NewRole = newRole;
             ev.IsAllowed = newRole != RoleTypeId.None;
+            ev.EscapeScenario = EscapeScenario.CustomEscape;
         }
     }
 


### PR DESCRIPTION
Hey apparently now it is needed to assign the `ev.EscapeScenario` since by default it is to `EscapeScenario.None`, the escape is not triggerd even with `ev.IsAllowed` to true. So i assigned it to `EscapeScenario.CustomEscape`.

thanks NW for breaking shit